### PR TITLE
Fix user input bug in Find command

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,11 @@ test {
     finalizedBy jacocoTestReport
 }
 
+run {
+    enableAssertions = true
+}
+
+
 task coverage(type: JacocoReport) {
     sourceDirectories.from files(sourceSets.main.allSource.srcDirs)
     classDirectories.from files(sourceSets.main.output)

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -148,13 +148,17 @@ Replace `path/to/CatPals` with the actual path to your folder. For example:
 ---
 
 **Step 4: Run the Application**
+
 Now that the terminal window is open, simply type the following command exactly as it appears and press **Enter**:
 
 `java -jar catpals.jar`
 
-> **Note:** If the file you downloaded has a different name (like `catpals-v1.2.jar`), make sure you type that exact name after the `-jar` part!
+<div markdown="block" class="alert alert-info"> : **Note:**
+If the file you downloaded has a different name (like `catpals-v1.2.jar`), make sure you type that exact name after the `-jar` part!
+</div>
 
 **Step 5: Start Using CatPals!**
+
 If the app runs successfully, you should see a window pop up with a list of cats and a command box at the bottom. You can start typing commands to manage your cat profiles. For example, try typing `help` and pressing Enter to see the help message.
 
 Some example commands you can try:
@@ -328,13 +332,14 @@ Format: `find n/CAT_NAME`, `find l/LOCATION`, `find t/TRAIT`, or `find h/HEALTH_
   Matches any cat that is marked as either Friendly OR Playful.
 * **Finding names with multiple keywords:**`find n/Alex n/Li`
   Matches cats named Alex as well as cats with the last name Li (e.g., Jet Li).
-* **Combining categories:** `find n/Snowy t/Fluffy`
-  Matches any cat that has the name Snowy OR is tagged as Fluffy.
-* **Searching by partial location:**`find l/Arts`
-  Matches cats at Arts Canteen, Arts Plaza, etc.
+* **Combining categories:** `find l/COM3 t/Fluffy`
+  Matches any cat that is in COM3 AND is tagged as Fluffy.
 
->[!IMPORTANT]
-> Ensure there is no space between the prefix (like n/) and your search word. For example, use n/Snowy, not n/ Snowy.
+
+<div markdown="block" class="alert alert-warning">:exclamation: **Caution:**
+Ensure there is an identifier flag before each keyword if multiple are used. For example, use t/friendly t/white, 
+not t/friendly white.
+</div>  
 
 ### Deleting a cat : `delete`
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TRAIT;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
@@ -29,36 +28,52 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
+        assert args != null : "args passed to parser should never be null";
         logger.info("Parsing FindCommand with arguments: " + args);
 
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_LOCATION, PREFIX_TRAIT, PREFIX_HEALTH);
 
-        // Validation and keyword extraction
-        if (!argMultimap.getPreamble().isEmpty()) {
-            // Reject any input with preamble (non-prefix text)
-            logger.warning("Parsing failed: Preamble found without prefixes in input: " + args);
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        // Validation logic
+        if (!argMultimap.getPreamble().isEmpty() || !isAnyPrefixPresent(argMultimap)) {
+            logger.warning("Parsing failed: Missing prefixes or invalid preamble.");
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        if (isAnyPrefixPresent(argMultimap)) {
-            // Prefixes present - parse them
-            List<String> nameKeywords = getKeywordsFromPrefix(argMultimap, PREFIX_NAME);
-            List<String> locationKeywords = getKeywordsFromPrefix(argMultimap, PREFIX_LOCATION);
-            List<String> traitKeywords = getKeywordsFromPrefix(argMultimap, PREFIX_TRAIT);
-            List<String> healthKeywords = getKeywordsFromPrefix(argMultimap, PREFIX_HEALTH);
+        checkForMultipleKeywords(argMultimap);
 
-            logger.fine(String.format("Parsed keywords - Names: %d, Locations: %d, Traits: %d, Health: %d",
-                    nameKeywords.size(), locationKeywords.size(), traitKeywords.size(), healthKeywords.size()));
+        // Extracting keywords - requiring individual flags for each keyword
+        List<String> nameKeywords = getKeywordsFromPrefix(argMultimap, PREFIX_NAME);
+        List<String> locationKeywords = getKeywordsFromPrefix(argMultimap, PREFIX_LOCATION);
+        List<String> traitKeywords = getKeywordsFromPrefix(argMultimap, PREFIX_TRAIT);
+        List<String> healthKeywords = getKeywordsFromPrefix(argMultimap, PREFIX_HEALTH);
 
-            return new FindCommand(new CatContainsKeywordsPredicate(
-                    nameKeywords, locationKeywords, traitKeywords, healthKeywords));
-        } else {
-            // No prefixes and no preamble - invalid (empty input or whitespace only)
-            logger.warning("Parsing failed: No prefixes in input: " + args);
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        // Post-parsing assertions to ensure logic integrity
+        assert nameKeywords != null : "Keyword list should be empty, not null";
+        assert locationKeywords != null : "Keyword list should be empty, not null";
+
+        logger.fine("Successfully parsed FindCommand with specific flags.");
+
+        return new FindCommand(new CatContainsKeywordsPredicate(
+                nameKeywords, locationKeywords, traitKeywords, healthKeywords));
+    }
+
+    /**
+     * Checks if any prefix contains multiple words (separated by spaces).
+     * @throws ParseException if a prefix contains more than one word.
+     */
+    private void checkForMultipleKeywords(ArgumentMultimap argMultimap) throws ParseException {
+        Prefix[] prefixes = {PREFIX_NAME, PREFIX_LOCATION, PREFIX_TRAIT, PREFIX_HEALTH};
+
+        for (Prefix prefix : prefixes) {
+            List<String> values = argMultimap.getAllValues(prefix);
+            for (String value : values) {
+                if (value.trim().contains(" ")) {
+                    logger.warning("User provided multiple keywords for a single flag: " + prefix + value);
+                    throw new ParseException("Each keyword must be preceded by its identifier flag "
+                            + "(e.g., t/friendly t/calico).");
+                }
+            }
         }
     }
 
@@ -73,11 +88,14 @@ public class FindCommandParser implements Parser<FindCommand> {
 
     /**
      * Extracts keywords from the multimap for a specific prefix.
-     * Splits values by whitespace to allow multiple keywords per flag (e.g., t/friendly calico).
+     * Splits values by identifiers to allow multiple keywords per command (e.g., t/friendly t/calico).
      */
     private List<String> getKeywordsFromPrefix(ArgumentMultimap argMultimap, Prefix prefix) {
+        assert argMultimap != null : "ArgumentMultimap cannot be null";
+        assert prefix != null : "Prefix cannot be null";
+
         return argMultimap.getAllValues(prefix).stream()
-                .flatMap(val -> Arrays.stream(val.split("\\s+")))
+                .map(String::trim)
                 .filter(val -> !val.isEmpty())
                 .toList();
     }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -35,12 +35,17 @@ public class FindCommandParserTest {
                 Arrays.asList("Mochi"), Arrays.asList("UTown"),
                 Arrays.asList("calico"), Collections.emptyList());
         assertParseSuccess(parser, " n/Mochi l/UTown t/calico", new FindCommand(multipleFlagsPredicate));
+    }
 
-        // Multiple keywords within flags
-        CatContainsKeywordsPredicate multiKeywordPredicate = new CatContainsKeywordsPredicate(
-                Collections.emptyList(), Collections.emptyList(),
-                Arrays.asList("friendly", "white"), Collections.emptyList());
-        assertParseSuccess(parser, " t/friendly white", new FindCommand(multiKeywordPredicate));
+    @Test
+    public void parse_multipleKeywordsWithoutFlags_throwsParseException() {
+        // Testing name flag with multiple words
+        assertParseFailure(parser, " n/Mochi Luna",
+                "Each keyword must be preceded by its identifier flag (e.g., t/friendly t/calico).");
+
+        // Testing trait flag with multiple words
+        assertParseFailure(parser, " t/calico friendly",
+                "Each keyword must be preceded by its identifier flag (e.g., t/friendly t/calico).");
     }
 
 }


### PR DESCRIPTION
**What's new:**

- Fixed a bug in the `find` feature that allows users to input multiple keywords within one identifier flag (i.e. `t/friendly white` instead of `t/friendly t/white`)
- Updated test cases accordingly
- Fixed some formatting issues in User Guide
- Enabled assertions in Build.gradle